### PR TITLE
Optimize queries in Room.open and controllers

### DIFF
--- a/app/controllers/api/v1/channels_controller.rb
+++ b/app/controllers/api/v1/channels_controller.rb
@@ -63,7 +63,7 @@ class Api::V1::ChannelsController < ApplicationController
   end
 
   def filter
-    @channels = Channel.includes(:platform, :member)
+    @channels = Channel.eager_load(:platform, :member)
                        .of_platforms(params[:platforms])
                        .of_members(params[:members])
   end

--- a/app/controllers/api/v1/lives_controller.rb
+++ b/app/controllers/api/v1/lives_controller.rb
@@ -97,7 +97,7 @@ class Api::V1::LivesController < ApplicationController
   # rubocop:enable Metrics/MethodLength
 
   def filter
-    @lives = Live.includes(:channel, :video, room: :platform)
+    @lives = Live.eager_load(:channel, :video, room: :platform)
                  .of_channels(params[:channels])
     %i[start_before start_after].each do |key|
       param = params[key]

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -7,9 +7,7 @@ class Room < ApplicationRecord
   validate :validate_room_format
 
   scope :open, lambda { |channel|
-    joins(:platform, :lives)
-      .where(lives: { duration: nil, channel: channel },
-             platform: channel.platform)
+    joins(:lives).merge(Live.not_ended.of_channels(channel))
   }
 
   def validate_room_format


### PR DESCRIPTION
* Remove redundant validation in Room.open.
* Use eager_load which generates only one SQL to speed up the overall query time.