### PR TITLE
Support members mask in Lives controller

### DIFF
--- a/app/controllers/api/v1/lives_controller.rb
+++ b/app/controllers/api/v1/lives_controller.rb
@@ -97,6 +97,7 @@ class Api::V1::LivesController < ApplicationController
 
   def filter
     @lives = Live.eager_load(:channel, :video, room: :platform)
+                 .of_members(Transform.solve_mask(params[:members_mask]))
                  .of_channels(params[:channels])
     %i[start_before start_after].each do |key|
       param = params[key]

--- a/app/models/live.rb
+++ b/app/models/live.rb
@@ -16,6 +16,9 @@ class Live < ApplicationRecord
   scope :of_channels, lambda { |channels|
     where(channel: channels) if channels.present?
   }
+  scope :of_members, lambda { |members|
+    joins(:channel).merge(Channel.of_members(members)) if members.present?
+  }
   scope :start_after, lambda { |time|
     where('lives.start_at >= ?', time) if time.present?
   }

--- a/lib/utils/transform.rb
+++ b/lib/utils/transform.rb
@@ -24,5 +24,11 @@ class Transform
     def record!(param, model)
       model.find param
     end
+
+    def solve_mask(mask)
+      return nil unless mask
+
+      mask.chars.each_with_index.map { |char, index| char == '1' ? index + 1 : nil }.compact
+    end
   end
 end

--- a/test/models/live_test.rb
+++ b/test/models/live_test.rb
@@ -60,6 +60,14 @@ class LiveTest < ActiveSupport::TestCase
     assert_equal 0, lives_from_channel_two.size
   end
 
+  test 'should scope of_members' do
+    lives_from_member_one = Live.of_members members(:test_1)
+    lives_from_member_two = Live.of_members members(:test_2)
+
+    assert_equal 6, lives_from_member_one.size
+    assert_equal 0, lives_from_member_two.size
+  end
+
   test 'should scope start_after' do
     lives = Live.start_after Time.current
 

--- a/test/utils/transform_test.rb
+++ b/test/utils/transform_test.rb
@@ -28,4 +28,15 @@ class TransformTest < ActionView::TestCase
       Transform.allocate(w_3, c_7)
     )
   end
+
+  test 'solve mask' do
+    assert_nil Transform.solve_mask(nil)
+    assert_equal [], Transform.solve_mask('undefined')
+    assert_equal [], Transform.solve_mask('')
+    assert_equal [1], Transform.solve_mask('1')
+    assert_equal [1, 3], Transform.solve_mask('101')
+    assert_equal [3], Transform.solve_mask('001')
+    assert_equal [3], Transform.solve_mask('00100000')
+    assert_equal [], Transform.solve_mask('00000000')
+  end
 end


### PR DESCRIPTION
Lives controller now support passing a query string like `membersMask=10001` to indicate that only members with id `1` and `5` is needed.